### PR TITLE
ci: add Aurora `next-eval` queue option

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,12 +2,12 @@
 spec:
   inputs:
     runner:
-      options: [aurora, sunspot]
+      options: [aurora, aurora-eval, sunspot]
       default: aurora
       description: CI runners to use
     root_dir:
       rules:
-        - if: $[[ inputs.runner ]] == 'aurora'
+        - if: $[[ inputs.runner ]] =~ '/^aurora.*/'
           default: '/lus/flare/projects/datascience/frameworks-ci'
         - if: $[[ inputs.runner ]] == 'sunspot'
           default: '/lus/tegu/projects/datascience/frameworks-ci'


### PR DESCRIPTION
Adds Aurora's `next-eval` nodes as an option when interactively running our GitLab CI pipeline. This tag is mutually exclusive to the general `aurora` nodes, and will be unpopulated (and thus time out) while there isn't a `next-eval`.