### PR TITLE
deps/llvm: don't hardcode build hash

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,9 @@ spec:
     ipex_version:
       default: ''
       description: IPEX version to build
+    vllm_version:
+      default: main
+      description: vLLM version to build
 ---
 
 variables:
@@ -36,6 +39,7 @@ variables:
   FRAMEWORKS_TRITON_VERSION: $[[ inputs.triton_version ]]
   FRAMEWORKS_TORCHCCL_VERSION: $[[ inputs.torchccl_version ]]
   FRAMEWORKS_IPEX_VERSION: $[[ inputs.ipex_version ]]
+  FRAMEWORKS_VLLM_VERSION: $[[ inputs.vllm_version ]]
 
 include:
   - local: 'templates/common.yml'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,9 @@ spec:
     torch_version:
       default: main
       description: PyTorch version to build
+    triton_version:
+      default: main
+      description: Triton-XPU version to build
     torchccl_version:
       default: ''
       description: torchCCL version to build
@@ -30,6 +33,7 @@ variables:
   FRAMEWORKS_ROOT_DIR: $[[ inputs.root_dir ]]
   FRAMEWORKS_PYTHON_VERSION: $[[ inputs.python_version ]]
   FRAMEWORKS_TORCH_VERSION: $[[ inputs.torch_version ]]
+  FRAMEWORKS_TRITON_VERSION: $[[ inputs.triton_version ]]
   FRAMEWORKS_TORCHCCL_VERSION: $[[ inputs.torchccl_version ]]
   FRAMEWORKS_IPEX_VERSION: $[[ inputs.ipex_version ]]
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ configured via the following environment variables.
 | `FRAMEWORKS_ROOT_DIR` | Directory to store built artifacts | `/lus/flare/projects/datascience/frameworks-ci` (Lustre allocation on Aurora) |
 | `FRAMEWORKS_PYTHON_VERSION` | Python version to build against | `3.12` |
 | `FRAMEWORKS_TORCH_VERSION` | PyTorch version to build (`git` ref) | `v2.10.0` |
+| `FRAMEWORKS_TRITON_VERSION` | Triton-XPU version to build (`git` ref) | `main` |
 | `FRAMEWORKS_TORCHCCL_VERSION` | torchCCL version to build (`git` ref) | `master` |
 | `FRAMEWORKS_IPEX_VERSION` | IPEX version to build (`git` ref) | `xpu-main` |
+| `FRAMEWORKS_VLLM_VERSION` | vLLM version to build (`git` ref) | `main` |
 
 Then, run any of the scripts in `nightly_wheels`. The resultant builds/logs
 will then be in `$FRAMEWORKS_ROOT_DIR/$(whoami)`.

--- a/deps/llvm
+++ b/deps/llvm
@@ -3,11 +3,15 @@
 source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../ci-lib.sh"
 
 # 0) Only build if not already cached
-[ -d "$FRAMEWORKS_ROOT_DIR/llvm" ] && exit 0
+LLVM_HASH="$(curl -s "https://raw.githubusercontent.com/intel/intel-xpu-backend-for-triton/refs/heads/$FRAMEWORKS_TRITON_VERSION/cmake/llvm-hash.txt")"
+if [ -d "$FRAMEWORKS_ROOT_DIR/llvm-$LLVM_HASH" ]; then
+	echo "llvm-$LLVM_HASH already cached in $FRAMEWORKS_ROOT_DIR!" >&2
+	exit 0
+fi
 
 # 1) Pull source and gen build environment
 gen_build_dir_with_git 'https://github.com/llvm/llvm-project'
-git fetch origin 979132a02d146ec79e2f046e31877516d7f32d20
+git fetch origin "$LLVM_HASH"
 git checkout FETCH_HEAD
 setup_build_env
 
@@ -27,7 +31,7 @@ cmake -G Ninja -S llvm -B build \
   -DLLVM_ENABLE_PROJECTS="mlir;llvm;lld" \
   -DLLVM_TARGETS_TO_BUILD="Native;NVPTX;AMDGPU" \
   -DLLVM_INSTALL_UTILS=ON \
-  -DCMAKE_INSTALL_PREFIX="$FRAMEWORKS_ROOT_DIR/llvm" \
+  -DCMAKE_INSTALL_PREFIX="$FRAMEWORKS_ROOT_DIR/llvm-$LLVM_HASH" \
   -DCMAKE_C_COMPILER="clang" \
   -DCMAKE_CXX_COMPILER="clang++" > configure_llvm.log 2>&1
 

--- a/deps/llvm
+++ b/deps/llvm
@@ -33,15 +33,21 @@ cmake -G Ninja -S llvm -B build \
   -DLLVM_INSTALL_UTILS=ON \
   -DCMAKE_INSTALL_PREFIX="$FRAMEWORKS_ROOT_DIR/llvm-$LLVM_HASH" \
   -DCMAKE_C_COMPILER="clang" \
-  -DCMAKE_CXX_COMPILER="clang++" > configure_llvm.log 2>&1
+  -DCMAKE_CXX_COMPILER="clang++" > configure_llvm.log 2>&1 || {
+	artifact_out "configure_llvm.log"
+	exit 1
+}
+artifact_out "configure_llvm.log"
 
 section_end "configure_llvm[collapsed=true]"
-artifact_out "configure_llvm.log"
 
 # 3) Build & Archive
 section_start "build_llvm[collapsed=true]"
 
-ninja -C build install > build_llvm.log 2>&1
+ninja -C build install > build_llvm.log 2>&1 || {
+	artifact_out "build_llvm.log"
+	exit 1
+}
+artifact_out "build_llvm.log"
 
 section_end "build_llvm[collapsed=true]"
-artifact_out "build_llvm.log"

--- a/nightly_wheels/triton
+++ b/nightly_wheels/triton
@@ -12,7 +12,8 @@ setup_uv_venv -r python/requirements.txt
 export PATH="$(dirname $(which icpx))/compiler:$PATH"
 export TRITON_BUILD_WITH_CLANG_LLD=true
 
-export LLVM_SYSPATH="$FRAMEWORKS_ROOT_DIR/llvm"
+LLVM_HASH="$(cat cmake/llvm-hash.txt)"
+export LLVM_SYSPATH="$FRAMEWORKS_ROOT_DIR/llvm-$LLVM_HASH"
 export LLVM_LIBRARY_DIR="$LLVM_SYSPATH/lib"
 export LLVM_INCLUDE_DIRS="$LLVM_SYSPATH/include"
 

--- a/nightly_wheels/triton
+++ b/nightly_wheels/triton
@@ -3,7 +3,7 @@
 source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../ci-lib.sh"
 
 # 1) Pull source and gen build environment
-gen_build_dir_with_git 'https://github.com/intel/intel-xpu-backend-for-triton'
+gen_build_dir_with_git 'https://github.com/intel/intel-xpu-backend-for-triton' -b "$FRAMEWORKS_TRITON_VERSION"
 setup_build_env
 
 setup_uv_venv -r python/requirements.txt

--- a/nightly_wheels/vllm
+++ b/nightly_wheels/vllm
@@ -3,7 +3,7 @@
 source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../ci-lib.sh"
 
 # 1) Pull source and gen build environment
-gen_build_dir_with_git 'https://github.com/vllm-project/vllm'
+gen_build_dir_with_git 'https://github.com/vllm-project/vllm' -b "$FRAMEWORKS_VLLM_VERSION"
 setup_build_env
 
 artifact_in "torch-*.whl"


### PR DESCRIPTION
- Updates the LLVM build script to pull the pinned hash from Triton-XPU prior to building. Fixes #19.
- Adds a pin for vLLM and Triton-XPU. Fixes #21.
- Fixes failed LLVM builds not archiving their associated compilation logs. Resolves #20.