### PR TITLE
deps/llvm: build with `gcc`

### DIFF
--- a/deps/llvm
+++ b/deps/llvm
@@ -18,12 +18,20 @@ setup_build_env
 # 2) Set LLVM build configuration for Triton-XPU
 section_start "configure_llvm[collapsed=true]"
 
-export PATH="$(dirname $(which icpx))/compiler:$PATH"
+# oneAPI 2025.3.2 has a regression which causes it to crash compiling LLVM
+# https://github.com/llvm/llvm-project/issues/188249
+# export PATH="$(dirname $(which icpx))/compiler:$PATH"
+
+# -DLLVM_ENABLE_LLD=ON \
+# -DCMAKE_C_COMPILER="clang" \
+# -DCMAKE_CXX_COMPILER="clang++" \
+ 
+module load gcc/13.4.0
+
 cmake -G Ninja -S llvm -B build \
   -DCMAKE_BUILD_TYPE=Release \
   -DLLVM_CCACHE_BUILD=OFF \
   -DLLVM_ENABLE_ASSERTIONS=ON \
-  -DLLVM_ENABLE_LLD=ON \
   -DBUILD_SHARED_LIBS=OFF \
   -DLLVM_OPTIMIZED_TABLEGEN=ON \
   -DMLIR_ENABLE_BINDINGS_PYTHON=OFF \
@@ -32,11 +40,11 @@ cmake -G Ninja -S llvm -B build \
   -DLLVM_TARGETS_TO_BUILD="Native;NVPTX;AMDGPU" \
   -DLLVM_INSTALL_UTILS=ON \
   -DCMAKE_INSTALL_PREFIX="$FRAMEWORKS_ROOT_DIR/llvm-$LLVM_HASH" \
-  -DCMAKE_C_COMPILER="clang" \
-  -DCMAKE_CXX_COMPILER="clang++" > configure_llvm.log 2>&1 || {
+  -DCMAKE_C_COMPILER="gcc" \
+  -DCMAKE_CXX_COMPILER="g++" > configure_llvm.log 2>&1 || {
 	artifact_out "configure_llvm.log"
 	exit 1
-}
+  }
 artifact_out "configure_llvm.log"
 
 section_end "configure_llvm[collapsed=true]"


### PR DESCRIPTION
oneAPI 2025.3.2 has a regression which causes it to crash compiling LLVM.
https://github.com/llvm/llvm-project/issues/188249