### PR TITLE
llvm: pull commit hash from `llvm-info.json`

### DIFF
--- a/deps/llvm
+++ b/deps/llvm
@@ -3,7 +3,7 @@
 source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../ci-lib.sh"
 
 # 0) Only build if not already cached
-LLVM_HASH="$(curl -s "https://raw.githubusercontent.com/intel/intel-xpu-backend-for-triton/refs/heads/$FRAMEWORKS_TRITON_VERSION/cmake/llvm-hash.txt")"
+LLVM_HASH="$(curl -s "https://raw.githubusercontent.com/intel/intel-xpu-backend-for-triton/refs/heads/$FRAMEWORKS_TRITON_VERSION/cmake/llvm-info.json" | jq -r ".llvm_hash")"
 if [ -d "$FRAMEWORKS_ROOT_DIR/llvm-$LLVM_HASH" ]; then
 	echo "llvm-$LLVM_HASH already cached in $FRAMEWORKS_ROOT_DIR!" >&2
 	exit 0

--- a/nightly_wheels/triton
+++ b/nightly_wheels/triton
@@ -12,7 +12,7 @@ setup_uv_venv -r python/requirements.txt
 export PATH="$(dirname $(which icpx))/compiler:$PATH"
 export TRITON_BUILD_WITH_CLANG_LLD=true
 
-LLVM_HASH="$(cat cmake/llvm-hash.txt)"
+LLVM_HASH="$(jq -r ".llvm_hash" cmake/llvm-info.json)"
 export LLVM_SYSPATH="$FRAMEWORKS_ROOT_DIR/llvm-$LLVM_HASH"
 export LLVM_LIBRARY_DIR="$LLVM_SYSPATH/lib"
 export LLVM_INCLUDE_DIRS="$LLVM_SYSPATH/include"


### PR DESCRIPTION
Hash is now stored in a JSON file.
https://github.com/triton-lang/triton/pull/10358