### PR TITLE
llvm: use gcc/14.3.0 on Sunspot

### DIFF
--- a/deps/llvm
+++ b/deps/llvm
@@ -26,8 +26,6 @@ section_start "configure_llvm[collapsed=true]"
 # -DCMAKE_C_COMPILER="clang" \
 # -DCMAKE_CXX_COMPILER="clang++" \
  
-module load gcc/13.4.0
-
 cmake -G Ninja -S llvm -B build \
   -DCMAKE_BUILD_TYPE=Release \
   -DLLVM_CCACHE_BUILD=OFF \


### PR DESCRIPTION
`libstdc++` uses gcc/14.3.0 on Sunspot currently and won't link with older GCC versions.