### PR TITLE
torch: fix Aurora/Sunspot oneAPI builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,7 +58,7 @@ include:
   - local: 'templates/nightly-wheel.yml'
     inputs:
       wheel: torch
-      needs: [triton]
+      needs: [triton, pti-gpu]
   - local: 'templates/nightly-wheel.yml'
     inputs:
       wheel: intel_extension_for_pytorch
@@ -93,6 +93,18 @@ llvm:
   extends: .common-runner
   script:
     - ./deps/llvm
+  artifacts:
+    when: always
+    expire_in: never
+    paths:
+      - "*.log"
+
+# Updated `pti-gpu` build
+pti-gpu:
+  stage: build
+  extends: .common-runner
+  script:
+    - ./deps/pti-gpu
   artifacts:
     when: always
     expire_in: never

--- a/deps/llvm
+++ b/deps/llvm
@@ -18,18 +18,12 @@ setup_build_env
 # 2) Set LLVM build configuration for Triton-XPU
 section_start "configure_llvm[collapsed=true]"
 
-# oneAPI 2025.3.2 has a regression which causes it to crash compiling LLVM
-# https://github.com/llvm/llvm-project/issues/188249
-# export PATH="$(dirname $(which icpx))/compiler:$PATH"
-
-# -DLLVM_ENABLE_LLD=ON \
-# -DCMAKE_C_COMPILER="clang" \
-# -DCMAKE_CXX_COMPILER="clang++" \
- 
+export PATH="$(dirname $(which icpx))/compiler:$PATH"
 cmake -G Ninja -S llvm -B build \
   -DCMAKE_BUILD_TYPE=Release \
   -DLLVM_CCACHE_BUILD=OFF \
   -DLLVM_ENABLE_ASSERTIONS=ON \
+  -DLLVM_ENABLE_LLD=ON \
   -DBUILD_SHARED_LIBS=OFF \
   -DLLVM_OPTIMIZED_TABLEGEN=ON \
   -DMLIR_ENABLE_BINDINGS_PYTHON=OFF \
@@ -38,11 +32,11 @@ cmake -G Ninja -S llvm -B build \
   -DLLVM_TARGETS_TO_BUILD="Native;NVPTX;AMDGPU" \
   -DLLVM_INSTALL_UTILS=ON \
   -DCMAKE_INSTALL_PREFIX="$FRAMEWORKS_ROOT_DIR/llvm-$LLVM_HASH" \
-  -DCMAKE_C_COMPILER="gcc" \
-  -DCMAKE_CXX_COMPILER="g++" > configure_llvm.log 2>&1 || {
+  -DCMAKE_C_COMPILER="clang" \
+  -DCMAKE_CXX_COMPILER="clang++" > configure_llvm.log 2>&1 || {
 	artifact_out "configure_llvm.log"
 	exit 1
-  }
+}
 artifact_out "configure_llvm.log"
 
 section_end "configure_llvm[collapsed=true]"

--- a/deps/pti-gpu
+++ b/deps/pti-gpu
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../ci-lib.sh"
+
+# 1) Pull source and gen build environment
+gen_build_dir_with_git 'https://github.com/intel/pti-gpu'
+setup_build_env
+
+# 2) Set build configuration for pti-gpu
+section_start "configure_pti-gpu[collapsed=true]"
+
+cd sdk
+cmake -S . \
+	-B build \
+	-DCMAKE_BUILD_TYPE=Release > configure_pti-gpu.log 2>&1 || {
+	artifact_out "configure_pti-gpu.log"
+	exit 1
+}
+artifact_out "configure_pti-gpu.log"
+
+section_end "configure_pti-gpu[collapsed=true]"
+
+# 3) Build & Archive
+section_start "build_pti-gpu[collapsed=true]"
+
+cmake --install build \
+	--config Release \
+	--prefix "$FRAMEWORKS_RUN_DIR/pti-gpu" > build_pti-gpu.log 2>&1 || {
+	artifact_out "build_pti-gpu.log"
+	exit 1
+}
+artifact_out "build_pti-gpu.log"
+
+section_end "build_pti-gpu[collapsed=true]"

--- a/deps/pti-gpu
+++ b/deps/pti-gpu
@@ -20,15 +20,27 @@ artifact_out "configure_pti-gpu.log"
 
 section_end "configure_pti-gpu[collapsed=true]"
 
-# 3) Build & Archive
+# 3) Build
 section_start "build_pti-gpu[collapsed=true]"
 
-cmake --install build \
-	--config Release \
-	--prefix "$FRAMEWORKS_RUN_DIR/pti-gpu" > build_pti-gpu.log 2>&1 || {
+cmake --build build \
+	--parallel "$MAX_JOBS" > build_pti-gpu.log 2>&1 || {
 	artifact_out "build_pti-gpu.log"
 	exit 1
 }
 artifact_out "build_pti-gpu.log"
 
 section_end "build_pti-gpu[collapsed=true]"
+
+# 4) Install
+section_start "install_pti-gpu[collapsed=true]"
+
+cmake --install build \
+	--config Release \
+	--prefix "$FRAMEWORKS_RUN_DIR/pti-gpu" > install_pti-gpu.log 2>&1 || {
+	artifact_out "install_pti-gpu.log"
+	exit 1
+}
+artifact_out "install_pti-gpu.log"
+
+section_end "install_pti-gpu[collapsed=true]"

--- a/nightly_wheels/intel_extension_for_pytorch
+++ b/nightly_wheels/intel_extension_for_pytorch
@@ -10,13 +10,6 @@ artifact_in "torch-*.whl"
 
 setup_uv_venv -r requirements.txt pip *.whl
 
-# 2) Set IPEX build configuration
-CC="$(which gcc)"
-export CC
-CXX="$(which g++)"
-export CXX
-export INTELONEAPIROOT="$ONEAPI_ROOT"
-
-# 3) Build & Archive
+# 2) Build & Archive
 build_bdist_wheel
 artifact_out "intel_extension_for_pytorch-*.whl"

--- a/nightly_wheels/torch
+++ b/nightly_wheels/torch
@@ -52,6 +52,78 @@ index b027d63f1a7..cbe3e9fc1af 100644
 2.50.1 (Apple Git-155)
 EOF
 
+# Patch torch-xpu-ops to support oneAPI
+TORCH_XPU_OPS_COMMIT="$(cat third_party/xpu.txt)"
+git clone 'https://github.com/intel/torch-xpu-ops.git' third_party/torch-xpu-ops
+pushd third_party/torch-xpu-ops
+git fetch origin "$TORCH_XPU_OPS_COMMIT"
+git checkout FETCH_HEAD
+git am <<'EOL'
+From 94cedda6de8da47b74b64d77a3e7758839610828 Mon Sep 17 00:00:00 2001
+From: Ethan Wong <ewong@anl.gov>
+Date: Mon, 27 Jul 2026 22:29:27 -0500
+Subject: [PATCH] cmake: support `IntelLLVM`
+
+---
+ CMakeLists.txt         | 8 ++++----
+ cmake/BuildFlags.cmake | 6 +++---
+ 2 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bdee938c..efb67683 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -66,10 +66,10 @@ if(USE_XCCL)
+ endif()
+ 
+ set(USE_SYCLTLA ON)
+-if(WIN32 OR NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.0)
+-  set(USE_SYCLTLA OFF)
+-  message(WARNING "SYCL-TLA is not build as it only supports GCC >= 13.0 as CXX Compiler on Linux Platform!")
+-endif()
++# if(WIN32 OR NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.0)
++#   set(USE_SYCLTLA OFF)
++#   message(WARNING "SYCL-TLA is not build as it only supports GCC >= 13.0 as CXX Compiler on Linux Platform!")
++# endif()
+ 
+ if(USE_SYCLTLA)
+   include(${TORCH_XPU_OPS_ROOT}/cmake/SYCLTLA.cmake)
+diff --git a/cmake/BuildFlags.cmake b/cmake/BuildFlags.cmake
+index 9629dc86..795648ae 100644
+--- a/cmake/BuildFlags.cmake
++++ b/cmake/BuildFlags.cmake
+@@ -31,7 +31,7 @@ function(CHECK_SYCL_FLAG FLAG VARIABLE_NAME)
+ endfunction()
+ 
+ macro(set_build_flags)
+- set(_TORCH_XPU_OPS_SUPPORTED_COMPILERS "GNU" "MSVC")
++  set(_TORCH_XPU_OPS_SUPPORTED_COMPILERS "GNU" "MSVC" "IntelLLVM")
+   if(NOT CMAKE_CXX_COMPILER_ID IN_LIST _TORCH_XPU_OPS_SUPPORTED_COMPILERS)
+     message(WARNING "Not compiling with XPU. Currently only support GCC compiler on Linux and MSVC compiler on Windows as CXX compiler.")
+     return()
+@@ -71,7 +71,7 @@ macro(set_build_flags)
+     elseif(CMAKE_BUILD_TYPE MATCHES RelWithDebInfo)
+       list(APPEND SYCL_HOST_FLAGS /O2 /Z7)
+     endif()
+-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
++  else()
+     list(APPEND SYCL_HOST_FLAGS -fPIC)
+     list(APPEND SYCL_HOST_FLAGS -std=${CPP_STD})
+     list(APPEND SYCL_HOST_FLAGS -Wunused-variable)
+@@ -140,7 +140,7 @@ macro(set_build_flags)
+     list(APPEND SYCL_KERNEL_OPTIONS /Qftz-)
+     # Suppress warnings about dllexport.
+     list(APPEND SYCL_KERNEL_OPTIONS -Wno-ignored-attributes)
+-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
++  else()
+     list(APPEND SYCL_KERNEL_OPTIONS -std=${CPP_STD})
+     list(APPEND SYCL_KERNEL_OPTIONS -Wno-absolute-value)
+     # -fma which we used before is an alias used for -ffp-contract=fast for compatibility reasons
+-- 
+2.50.1 (Apple Git-155)
+EOL
+popd
+
 # 2) Set PyTorch build configuration
 export WERROR=0
 export REL_WITH_DEB_INFO=1

--- a/nightly_wheels/torch
+++ b/nightly_wheels/torch
@@ -11,6 +11,12 @@ artifact_in "triton-*.whl"
 # Must use uv-managed python for development headers
 setup_uv_venv --group dev pip mkl-static mkl-include *.whl
 
+# Use built pti-gpu
+export C_INCLUDE_PATH="$FRAMEWORKS_RUN_DIR/pti-gpu/include:$C_INCLUDE_PATH"
+export CPLUS_INCLUDE_PATH="$FRAMEWORKS_RUN_DIR/pti-gpu/include:$CPLUS_INCLUDE_PATH"
+export LIBRARY_PATH="$FRAMEWORKS_RUN_DIR/pti-gpu/lib:$LIBRARY_PATH"
+export Pti_DIR="$FRAMEWORKS_RUN_DIR/pti-gpu/lib/cmake/pti"
+
 # Patch OpenMP flag failure
 git am <<'EOF'
 From b4bdb5ec6901174f3c059e881bd1a479097dd24c Mon Sep 17 00:00:00 2001

--- a/nightly_wheels/torch
+++ b/nightly_wheels/torch
@@ -217,7 +217,6 @@ EOL
 
 # 2) Set PyTorch build configuration
 export WERROR=0
-export REL_WITH_DEB_INFO=1
 export USE_CUDA=0
 export USE_ROCM=0
 export USE_MKLDNN=1

--- a/nightly_wheels/torch
+++ b/nightly_wheels/torch
@@ -59,10 +59,49 @@ pushd third_party/torch-xpu-ops
 git fetch origin "$TORCH_XPU_OPS_COMMIT"
 git checkout FETCH_HEAD
 git am <<'EOL'
-From 94cedda6de8da47b74b64d77a3e7758839610828 Mon Sep 17 00:00:00 2001
+From b5744c10b5f63657319d7d4bdb312754353c36db Mon Sep 17 00:00:00 2001
+From: "Yu, Guangye" <guangye.yu@intel.com>
+Date: Tue, 28 Jul 2026 17:21:30 +0800
+Subject: [PATCH 1/2] Fix separate ops build failure due to Sleep.cpp (#4715)
+
+# Motivation
+
+Fix the broken build with `BUILD_SEPARATE_OPS=1` introduced by
+https://github.com/intel/torch-xpu-ops/pull/4385
+---
+ src/BuildOnLinux.cmake | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/src/BuildOnLinux.cmake b/src/BuildOnLinux.cmake
+index 466f782f..72fb1fcb 100644
+--- a/src/BuildOnLinux.cmake
++++ b/src/BuildOnLinux.cmake
+@@ -40,7 +40,16 @@ if(BUILD_SEPARATE_OPS)
+       ${sycl_lib}
+       SHARED
+       SYCL_SOURCES ${sycl_src})
+-    target_link_libraries(torch_xpu_ops PUBLIC ${sycl_lib})
++
++    # Sleep.cpp provides at::xpu::sleep, used by libtorch_python but not by any
++    # operator in libtorch_xpu. Since no symbol is referenced within
++    # libtorch_xpu, --as-needed drops it, leaving at::xpu::sleep unresolved at
++    # load time. Force-keep it as a NEEDED dependency.
++    if(name STREQUAL "Sleep")
++      target_link_libraries(torch_xpu_ops PUBLIC "-Wl,--no-as-needed" ${sycl_lib} "-Wl,--as-needed")
++    else()
++      target_link_libraries(torch_xpu_ops PUBLIC ${sycl_lib})
++    endif()
+     list(APPEND TORCH_XPU_OPS_LIBRARIES ${sycl_lib})
+ 
+     # Decouple with PyTorch cmake definition.
+-- 
+2.50.1 (Apple Git-155)
+
+
+From b6f5a976d18b23c14bfa6885a33319513cbfff4b Mon Sep 17 00:00:00 2001
 From: Ethan Wong <ewong@anl.gov>
 Date: Mon, 27 Jul 2026 22:29:27 -0500
-Subject: [PATCH] cmake: support `IntelLLVM`
+Subject: [PATCH 2/2] cmake: support `IntelLLVM`
 
 ---
  CMakeLists.txt         | 8 ++++----

--- a/nightly_wheels/torch
+++ b/nightly_wheels/torch
@@ -12,10 +12,7 @@ artifact_in "triton-*.whl"
 setup_uv_venv --group dev pip mkl-static mkl-include *.whl
 
 # 2) Set PyTorch build configuration
-CC="$(which gcc)"
-export CC
-CXX="$(which g++)"
-export CXX
+export WERROR=0
 export REL_WITH_DEB_INFO=1
 export USE_CUDA=0
 export USE_ROCM=0
@@ -33,10 +30,8 @@ export USE_NUMA=0
 export USE_MPI=1
 export USE_XPU=1
 export USE_XCCL=1
-export INTEL_MKL_DIR="$MKLROOT"
 export USE_AOT_DEVLIST='pvc'
 export TORCH_XPU_ARCH_LIST='pvc'
-export OCLOC_VERSION=24.39.1
 
 # 3) Build & Archive
 build_bdist_wheel

--- a/nightly_wheels/torch
+++ b/nightly_wheels/torch
@@ -11,6 +11,41 @@ artifact_in "triton-*.whl"
 # Must use uv-managed python for development headers
 setup_uv_venv --group dev pip mkl-static mkl-include *.whl
 
+# Patch OpenMP flag failure
+git am <<'EOF'
+From b4bdb5ec6901174f3c059e881bd1a479097dd24c Mon Sep 17 00:00:00 2001
+From: Ethan Wong <ewong@anl.gov>
+Date: Mon, 27 Jul 2026 19:32:12 -0500
+Subject: [PATCH] cmake/openmp: add flag check for IntelLLVM
+
+Newer versions of oneAPI use "IntelLLVM" as the compiler ID. Currently,
+cmake will fail to set the appropriate OpenMP flag, causing trivial
+build errors on submodule dependencies.
+---
+ cmake/Modules/FindOpenMP.cmake | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/cmake/Modules/FindOpenMP.cmake b/cmake/Modules/FindOpenMP.cmake
+index b027d63f1a7..cbe3e9fc1af 100644
+--- a/cmake/Modules/FindOpenMP.cmake
++++ b/cmake/Modules/FindOpenMP.cmake
+@@ -119,6 +119,12 @@ function(_OPENMP_FLAG_CANDIDATES LANG)
+     else()
+       set(OMP_FLAG_Intel "-qopenmp")
+     endif()
++    if(CMAKE_${LANG}_COMPILER_ID STREQUAL "IntelLLVM" AND
++      "x${CMAKE_${LANG}_COMPILER_FRONTEND_VARIANT}" STREQUAL "xMSVC")
++      set(OMP_FLAG_IntelLLVM "-Qiopenmp")
++    else()
++      set(OMP_FLAG_IntelLLVM "-fiopenmp")
++    endif()
+     set(OMP_FLAG_MIPSpro "-mp")
+     if(__header_dir MATCHES ".*Microsoft Visual Studio.*")
+       # MSVC header. No need to pass it as additional include.
+-- 
+2.50.1 (Apple Git-155)
+EOF
+
 # 2) Set PyTorch build configuration
 export WERROR=0
 export REL_WITH_DEB_INFO=1

--- a/nightly_wheels/torch
+++ b/nightly_wheels/torch
@@ -123,6 +123,58 @@ index 9629dc86..795648ae 100644
 2.50.1 (Apple Git-155)
 EOL
 popd
+git am <<'EOL'
+From 3d843079c8429068a41ec9647d6732ba2fe485f0 Mon Sep 17 00:00:00 2001
+From: Ethan Wong <ewong@anl.gov>
+Date: Mon, 27 Jul 2026 23:31:37 -0500
+Subject: [PATCH] caffe2: don't checkout existing `torch-xpu-ops`
+
+---
+ caffe2/CMakeLists.txt | 28 ++++++++++++++--------------
+ 1 file changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/caffe2/CMakeLists.txt b/caffe2/CMakeLists.txt
+index abe7f74a656..b92a065b251 100644
+--- a/caffe2/CMakeLists.txt
++++ b/caffe2/CMakeLists.txt
+@@ -1199,20 +1199,20 @@ if(USE_XPU)
+     if(NOT _exitcode EQUAL 0)
+       message(FATAL_ERROR "Fail to clone ${TORCH_XPU_OPS_REPO_URL}")
+     endif()
+-  endif()
+-  execute_process(
+-    COMMAND git fetch --quiet
+-    WORKING_DIRECTORY ${TORCH_XPU_OPS_DIR}
+-    RESULT_VARIABLE _exitcode)
+-  if(NOT _exitcode EQUAL 0)
+-    message(FATAL_ERROR "Fail to fetch ${TORCH_XPU_OPS_REPO_URL}")
+-  endif()
+-  execute_process(
+-    COMMAND git checkout --quiet ${TORCH_XPU_OPS_COMMIT}
+-    WORKING_DIRECTORY ${TORCH_XPU_OPS_DIR}
+-    RESULT_VARIABLE _exitcode)
+-  if(NOT _exitcode EQUAL 0)
+-    message(FATAL_ERROR "Fail to checkout ${TORCH_XPU_OPS_REPO_URL} to ${TORCH_XPU_OPS_COMMIT}")
++    execute_process(
++      COMMAND git fetch --quiet
++      WORKING_DIRECTORY ${TORCH_XPU_OPS_DIR}
++      RESULT_VARIABLE _exitcode)
++    if(NOT _exitcode EQUAL 0)
++      message(FATAL_ERROR "Fail to fetch ${TORCH_XPU_OPS_REPO_URL}")
++    endif()
++    execute_process(
++      COMMAND git checkout --quiet ${TORCH_XPU_OPS_COMMIT}
++      WORKING_DIRECTORY ${TORCH_XPU_OPS_DIR}
++      RESULT_VARIABLE _exitcode)
++    if(NOT _exitcode EQUAL 0)
++      message(FATAL_ERROR "Fail to checkout ${TORCH_XPU_OPS_REPO_URL} to ${TORCH_XPU_OPS_COMMIT}")
++    endif()
+   endif()
+ 
+   set(TORCH_XPU_OPS_INCLUDE_DIRS
+-- 
+2.50.1 (Apple Git-155)
+EOL
 
 # 2) Set PyTorch build configuration
 export WERROR=0

--- a/nightly_wheels/vllm
+++ b/nightly_wheels/vllm
@@ -8,37 +8,6 @@ setup_build_env
 
 artifact_in "torch-*.whl"
 
-# Patch `mwaitintrin.h` inclusion
-git am <<'EOF'
-From 02a92e76a875a6e34ff5d1b9a7f4cb936b741c02 Mon Sep 17 00:00:00 2001
-From: Ethan Wong <ewong@anl.gov>
-Date: Tue, 28 Jul 2026 08:23:17 -0500
-Subject: [PATCH] spinloop: include `x86intrin.h` for MWAITX
-
-`clang` has an error guard on including `mwaitxintrin.h` independently
-of `x86intrin.h`. Since the latter is a superset of the former, we can
-just include that instead.
----
- csrc/spinloop.cpp | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/csrc/spinloop.cpp b/csrc/spinloop.cpp
-index c29e48a5f..3285b9a3d 100644
---- a/csrc/spinloop.cpp
-+++ b/csrc/spinloop.cpp
-@@ -7,7 +7,7 @@ extern "C" {
- 
- #if defined(__i386__) || defined(__x86_64__)
-   #include <cpuid.h>
--  #include <mwaitxintrin.h>
-+  #include <x86intrin.h>
- #endif
- 
- #if defined(CLOCK_MONOTONIC_RAW)
--- 
-2.50.1 (Apple Git-155)
-EOF
-
 # Remove torch version requirement
 sed -i -e "/^torch==.*$/d" requirements/build/cuda.txt
 

--- a/nightly_wheels/vllm
+++ b/nightly_wheels/vllm
@@ -13,11 +13,7 @@ sed -i -e "/^torch==.*$/d" requirements/build/cuda.txt
 
 setup_uv_venv -r requirements/build/cuda.txt *.whl
 
-# 2) Set IPEX build configuration
-CC="$(which gcc)"
-export CC
-CXX="$(which g++)"
-export CXX
+# 2) Set vLLM build configuration
 export VLLM_TARGET_DEVICE=xpu
 
 # 3) Build & Archive

--- a/nightly_wheels/vllm
+++ b/nightly_wheels/vllm
@@ -8,6 +8,37 @@ setup_build_env
 
 artifact_in "torch-*.whl"
 
+# Patch `mwaitintrin.h` inclusion
+git am <<'EOF'
+From 02a92e76a875a6e34ff5d1b9a7f4cb936b741c02 Mon Sep 17 00:00:00 2001
+From: Ethan Wong <ewong@anl.gov>
+Date: Tue, 28 Jul 2026 08:23:17 -0500
+Subject: [PATCH] spinloop: include `x86intrin.h` for MWAITX
+
+`clang` has an error guard on including `mwaitxintrin.h` independently
+of `x86intrin.h`. Since the latter is a superset of the former, we can
+just include that instead.
+---
+ csrc/spinloop.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/csrc/spinloop.cpp b/csrc/spinloop.cpp
+index c29e48a5f..3285b9a3d 100644
+--- a/csrc/spinloop.cpp
++++ b/csrc/spinloop.cpp
+@@ -7,7 +7,7 @@ extern "C" {
+ 
+ #if defined(__i386__) || defined(__x86_64__)
+   #include <cpuid.h>
+-  #include <mwaitxintrin.h>
++  #include <x86intrin.h>
+ #endif
+ 
+ #if defined(CLOCK_MONOTONIC_RAW)
+-- 
+2.50.1 (Apple Git-155)
+EOF
+
 # Remove torch version requirement
 sed -i -e "/^torch==.*$/d" requirements/build/cuda.txt
 

--- a/nightly_wheels/vllm_xpu_kernels
+++ b/nightly_wheels/vllm_xpu_kernels
@@ -18,7 +18,7 @@ setup_uv_venv -r requirements.txt *.whl
 
 # Coerce using C++20 for torch>=2.13
 git am <<'EOF'
-From ee528e4f8b36730ba4dcba07827b46a842bf4547 Mon Sep 17 00:00:00 2001
+From 893c48c42be4b787bb559050300cda1e79a8fe7a Mon Sep 17 00:00:00 2001
 From: Ethan Wong <ewong@anl.gov>
 Date: Wed, 22 Jul 2026 17:39:36 -0500
 Subject: [PATCH 1/3] cmake: mandate c++20 for all kernels
@@ -78,7 +78,7 @@ index ba4bb67..1cb67aa 100644
 2.50.1 (Apple Git-155)
 
 
-From f00a4175524bc9603d6e3fec3bb39616f0b8f7b9 Mon Sep 17 00:00:00 2001
+From d8c757b3be2a62916da7082872ab6d1ffea0672a Mon Sep 17 00:00:00 2001
 From: Ethan Wong <ewong@anl.gov>
 Date: Wed, 22 Jul 2026 17:50:19 -0500
 Subject: [PATCH 2/3] [HACK] cmake: remove `-Werror`
@@ -88,7 +88,7 @@ Subject: [PATCH 2/3] [HACK] cmake: remove `-Werror`
  1 file changed, 2 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f3b219d..f161c72 100644
+index 828257b..8247b27 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -231,8 +231,6 @@ message(STATUS "FetchContent base directory: ${FETCHCONTENT_BASE_DIR}")
@@ -104,7 +104,7 @@ index f3b219d..f161c72 100644
 2.50.1 (Apple Git-155)
 
 
-From 82e22f171c13494317370010f4d06f91e4b5b00f Mon Sep 17 00:00:00 2001
+From bb98e11bbcea28df2d50e3944103dba6072ce6dd Mon Sep 17 00:00:00 2001
 From: Ethan Wong <ewong@anl.gov>
 Date: Thu, 23 Jul 2026 09:31:08 -0500
 Subject: [PATCH 3/3] Revert "get memory info (#249)"
@@ -127,7 +127,7 @@ Aurora driver does not support
  delete mode 100644 tests/test_get_memory_info.py
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f161c72..b72d275 100644
+index 8247b27..344564e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -262,9 +262,6 @@ if(VLLM_GPU_LANG STREQUAL "SYCL")
@@ -159,20 +159,20 @@ index f161c72..b72d275 100644
    include_directories("/usr/include")
  
 diff --git a/csrc/ops.h b/csrc/ops.h
-index 911b56c..255937d 100644
+index 4e6b0bf..9dd7c8a 100644
 --- a/csrc/ops.h
 +++ b/csrc/ops.h
-@@ -283,5 +283,3 @@ void merge_attn_states(
-     const torch::Tensor& prefix_lse,
-     const torch::Tensor& suffix_output,
-     const torch::Tensor& suffix_lse);
+@@ -285,5 +285,3 @@ void merge_attn_states(
+     const torch::Tensor& suffix_lse,
+     std::optional<int64_t> prefill_tokens_with_context = std::nullopt,
+     const std::optional<torch::Tensor>& output_scale = std::nullopt);
 -
 -std::tuple<int64_t, int64_t> getMemoryInfo(int64_t device_index);
 diff --git a/csrc/torch_bindings.cpp b/csrc/torch_bindings.cpp
-index 9498693..0a7f183 100644
+index 17ff0c2..4cc786f 100644
 --- a/csrc/torch_bindings.cpp
 +++ b/csrc/torch_bindings.cpp
-@@ -318,9 +318,6 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _cache_ops), cache_ops) {
+@@ -320,9 +320,6 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _cache_ops), cache_ops) {
        "gather_and_maybe_dequant_cache",
        torch::kXPU,
        &gather_and_maybe_dequant_cache);


### PR DESCRIPTION
This PR fixes `torch` builds on Aurora and Sunspot by coercing use of oneAPI across the entire Frameworks SDK. This requires patching of `torch` to fix trivial OpenMP build inclusion issues alongside the addition of building `pti-gpu` for `libkineto` to correctly build.